### PR TITLE
Filter test results

### DIFF
--- a/runscope_test.go
+++ b/runscope_test.go
@@ -36,6 +36,26 @@ func handleGet(t *testing.T, path string, code int, data string) {
 	})
 }
 
+func handleGetWitQueryString(t *testing.T, path string, qs url.Values, code int, data string) {
+	// strip query string from path to allow matching
+	u, _ := url.Parse(path)
+	if u.RawQuery != "" {
+		path = u.Path
+	}
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if !reflect.DeepEqual(qs, r.URL.Query()) {
+			t.Errorf("Request expect this query string parameters: %+v", qs)
+		}
+
+		if r.Method != "GET" {
+			t.Errorf("Request method: %v, want %v", r.Method, "GET")
+		}
+		w.WriteHeader(code)
+		fmt.Fprint(w, data)
+	})
+}
+
 func handlePost(t *testing.T, path string, code int, data string, iface interface{}, req interface{}) {
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,7 @@ package runscope
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 func unmarshal(content []byte, result interface{}) error {
@@ -15,4 +16,8 @@ func unmarshal(content []byte, result interface{}) error {
 		return fmt.Errorf("%s (%d): %+v", response.Error.Message, response.Error.Status, response.Meta)
 	}
 	return nil
+}
+
+func unixTimestampToFloat(t time.Time) float64 {
+	return float64(t.UnixNano()) / 1.0e9
 }


### PR DESCRIPTION
Extend API by adding function for filtering test results. This allows pagination over historical test results.